### PR TITLE
fixed image bug on homepage by fetching asset dynamically

### DIFF
--- a/src/app/_components/heroVid.tsx
+++ b/src/app/_components/heroVid.tsx
@@ -2,8 +2,24 @@
 import React from "react";
 import BlurFade from "@/components/magicui/blur-fade";
 import HeroVideoDialog from "@/components/magicui/hero-video-dialog";
+import getAsset from "@/server/get-asset";
 
 function HeroVid() {
+
+  const [imgURL, setImgURL] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const fetchThumbnail = async () => {
+      const url = await getAsset("assets/dashboard.png");
+      console.log(url)
+      return url;
+      
+    };
+    fetchThumbnail().then((url) => {
+      setImgURL(url);
+    });
+  }, []);
+
   return (
     <BlurFade delay={0.25 * 5} inView>
       <div className="relative w-full flex flex-col items-center justify-center">
@@ -11,14 +27,14 @@ function HeroVid() {
           className="dark:hidden block w-4/5"
           animationStyle="from-center"
           videoSrc="https://www.youtube.com/embed/0YueJwvDsoo?si=gUKMxmE-zoOwMR1s"
-          thumbnailSrc="/dashboard.png"
+          thumbnailSrc={imgURL || ""}
           thumbnailAlt="Hero Video"
         />
         <HeroVideoDialog
           className="hidden dark:block w-4/5"
           animationStyle="from-center"
           videoSrc="https://www.youtube.com/embed/0YueJwvDsoo?si=gUKMxmE-zoOwMR1s"
-          thumbnailSrc="/dashboard.png"
+          thumbnailSrc={imgURL || ""}
           thumbnailAlt="Hero Video"
         />
       </div>

--- a/src/app/_components/howItWorks.tsx
+++ b/src/app/_components/howItWorks.tsx
@@ -1,8 +1,24 @@
 "use client";
 
+import getAsset from "@/server/get-asset";
 import React from "react";
 
 function HowItWorks() {
+
+  const [imgURL, setImgURL] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    const fetchThumbnail = async () => {
+      const url = await getAsset("assets/dashboard.png");
+      console.log(url)
+      return url;
+      
+    };
+    fetchThumbnail().then((url) => {
+      setImgURL(url);
+    });
+  }, []);
+
   return (
     <div className="py-16 space-y-16 px-40 ">
       <div className="text-center space-y-3">
@@ -105,7 +121,7 @@ function HowItWorks() {
 
         <div className="col-span-2">
           <img
-            src="/dashboard.png"
+            src={imgURL || ""}
             alt=""
             className=" hover:scale-105 aspect-auto h-full w-full rounded-xl border border-neutral-300/50 object-cover object-left-top p-1 shadow-lg transition-all duration-100"
           />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,6 @@ import ProblemSec from "./_components/problemSec";
 import HowItWorks from "./_components/howItWorks";
 import HeroSection from "./_components/HeroSection";
 import SolutionSec from "./_components/solutionSec";
-import { ModeToggle } from "@/components/mode-toggle";
 
 export default function Home() {
   return (

--- a/src/server/get-asset.ts
+++ b/src/server/get-asset.ts
@@ -1,0 +1,17 @@
+"use server";
+import { app } from "@/lib/firebase";
+import { ref, getDownloadURL, getStorage } from "firebase/storage";
+
+const getAsset = async(filePath: string) => {
+    try {
+        const storage = getStorage(app);
+        const fileRef = ref(storage, filePath);
+        const url = await getDownloadURL(fileRef);
+        return url;
+    } catch (error) {
+        console.error("Error retrieving asset", error);
+        return null;
+    }
+};
+
+export default getAsset;


### PR DESCRIPTION
This pull request introduces changes to dynamically fetch and use assets from a server instead of using static file paths. The main updates involve importing a new utility function to retrieve assets and updating components to utilize this function.

### Dynamic asset fetching:

* [`src/app/_components/heroVid.tsx`](diffhunk://#diff-7882766d69c9806a5740894437bacfdcd7dfc71f133f984cc4e2dbb8f13b2752R5-R37): Added `getAsset` import and used it to asynchronously fetch the thumbnail URL for the `HeroVideoDialog` component.
* [`src/app/_components/howItWorks.tsx`](diffhunk://#diff-a40066c54731398fa9440d29fe2ebd1534e920092b3cf82c63d0e2fcf57303cbR3-R21): Added `getAsset` import and used it to asynchronously fetch the image URL for the `HowItWorks` component. [[1]](diffhunk://#diff-a40066c54731398fa9440d29fe2ebd1534e920092b3cf82c63d0e2fcf57303cbR3-R21) [[2]](diffhunk://#diff-a40066c54731398fa9440d29fe2ebd1534e920092b3cf82c63d0e2fcf57303cbL108-R124)

### Code cleanup:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL10): Removed unused import for `ModeToggle`.

### New utility function:

* [`src/server/get-asset.ts`](diffhunk://#diff-a2db7cfbca1ba5ecd446dd405e2d5eb23618ab1ededbc86cc21f9b90049ddd83R1-R17): Created a new `getAsset` function to retrieve asset URLs from Firebase storage.